### PR TITLE
Follow VCS guidelines for version fetch

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -21,7 +21,7 @@ md5sums=('SKIP'
 
 pkgver() {
   cd "${_gitname}"
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 }
 
 build() {


### PR DESCRIPTION
Produces same version tag you have, just goes by Arch suggestion for conformity.

See: https://wiki.archlinux.org/index.php/VCS_package_guidelines#The_pkgver.28.29_function
